### PR TITLE
add sitemap to speed up search engine find web page

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"> 
+  <url>
+    <loc>https://xcat2.github.io/index.html</loc>
+    <changefreq>weekly<changefreq>
+  </url>
+  <url>
+    <loc>https://xcat2.github.io/download.html</loc>
+    <changefreq>monthly<changefreq>
+  </url>
+</urlset>


### PR DESCRIPTION
For https://github.com/xcat2/xcat.org/issues/123

We had new url https://xcat2.github.io, if we wait for google spider to discover and crawl it, it may take several days or month. We can active tell google to speed up crawl our new urls. And we also tell changefreq of our web pages.

Ask Google to crawl URLs to speed up google find our site: xcat2.github.io
Refer to doc: https://www.google.com/webmasters/tools/submit-url
To submit a URL to the Google index, either submit a sitemap or use the Fetch as Google tool.

In this pull request, I created a sitemap.xml.