### PR TITLE
fix click "xCAT" to open index.html in new window

### DIFF
--- a/head.html
+++ b/head.html
@@ -26,7 +26,7 @@ button {
     border-image-outset: 0;
     color: rgb(125, 124, 124);
     cursor: pointer;
-    border: none；
+    border: none;
     padding: 0;
     font-size: 122%;
 }
@@ -145,7 +145,7 @@ img {
 </head>
 <body> 
 <a href="/"><img id="logo" src="webcontent/assets/image_38.png" alt="xCAT Logo" title="xCAT Logo"></a>
-<label class="gwd-label-1ezr"><span class="gwd-span-xx0b" onclick="window.location.href='index.html'">xCAT</span></label>
+<label class="gwd-label-1ezr"><span class="gwd-span-xx0b" onclick="window.open('index.html')">xCAT</span></label>
 <div id="toolbar">
         <button onclick="window.open('https://xcat.org/files/')">Download</button>
         <button onclick="window.open('https://xcat-docs.readthedocs.io/en/stable/')">Documentation</button>


### PR DESCRIPTION
### Issue 
When click "xCAT" which is behind "logo image", it will open `index.html` in itself page, since `head.html` is used by other web pages, this becomes a bug.

### Fixed in PR
When click "xCAT" which is behind "logo image", it will open index.html in a new tab in the browser, this can fix the issue.

### UT results
1. before this fix, click "xCAT" behind "logo image", it will refresh `head.html` using `index.html` like: https://xcat2.github.io/usecase.html
2. after fixed, Click "xCAT" behind "logo image", it will open `index.html` in a new tab in the browser.
like https://bybai.github.io/usecase.html