### PR TITLE
Remove the tabs in the download steps for go-xcat

### DIFF
--- a/download.html
+++ b/download.html
@@ -114,9 +114,9 @@ html,
 
             <div id="code_box">
                 <pre class="codetext">
-       wget https://raw.githubusercontent.com/xcat2/xcat-core/master/xCAT-server/share/xcat/tools/go-xcat -O - &gt;/tmp/go-xcat
-       chmod +x /tmp/go-xcat
-       /tmp/go-xcat
+wget https://raw.githubusercontent.com/xcat2/xcat-core/master/xCAT-server/share/xcat/tools/go-xcat -O - &gt;/tmp/go-xcat
+chmod +x /tmp/go-xcat
+/tmp/go-xcat
 </pre>
             </div>
 

--- a/webcontent/css/default.css
+++ b/webcontent/css/default.css
@@ -157,6 +157,7 @@ img {
     font-family: "Courier New", Monospace;
     font-size: 10pt;
     font-weight: 700;
+    padding-left: 2%;
 }
 
 .download_section {


### PR DESCRIPTION
For https://github.com/xcat2/xcat2.github.io/issues/15

###changes
remove tabs in the download steps for go-xcat, so that, if I copy and paste that above into a term window, commands can execute directly.

###UT:
https://bybai.github.io/download.html 