### PR TITLE
add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -1,0 +1,13 @@
+---
+name: Issue
+about: Normal issue for xCAT home page
+
+---
+
+**Issue description:**
+
+
+
+**Attach image (optional):**
+
+


### PR DESCRIPTION
For #29 

After create logo template, when user click issue button, there is only "Logo Change" template, if add a issue template, it is convenience and well-marked to choose.
<img width="935" alt="Screen Shot 2019-04-25 at 10 08 12 AM" src="https://user-images.githubusercontent.com/6743951/56705247-c9a44800-6742-11e9-8116-7a2ac4fc622b.png">

