### PR TITLE
Remove snapshot section

### DIFF
--- a/download.html
+++ b/download.html
@@ -137,8 +137,6 @@ chmod +x /tmp/go-xcat
             <ul>
                 <li><a href="#release_builds">Release Builds (Stable)</a> - latest generally available (GA) build for xCAT</li>
 
-                <li><a href="#snapshot_builds">Snapshot Builds</a> - snapshot build of the latest GA version of xCAT which may contain fixes but has not GAed yet</li>
-
                 <li><a href="#development_builds">Development Builds</a> - snapshot builds of the next version of xCAT</li>
 
                 <li><a href="https://sourceforge.net/p/xcat/wiki/XCAT_Developer_Guide/#building-xcat-core-from-xcat-core-git-repository">Build the xcat-core tarball from source</a> - xCAT 2.10 and later supports building the xcat-core tarball from the cloned repository.</li>
@@ -186,33 +184,6 @@ chmod +x /tmp/go-xcat
                         <p class="codetext">&nbsp; deb [arch=amd64] <a href="https://xcat.org/files/xcat/repos/apt/latest/xcat-core/">https://xcat.org/files/xcat/repos/apt/latest/xcat-core</a> trusty main</p>&nbsp; <i>For ppc64el servers:</i>
 
                         <p class="codetext">&nbsp; deb [arch=ppc64el] <a href="https://xcat.org/files/xcat/repos/apt/latest/xcat-core/">https://xcat.org/files/xcat/repos/apt/latest/xcat-core</a> trusty main</p>
-                    </li>
-                </ul>
-                <hr>
-
-                <h3><a name="snapshot_builds">Snapshot Builds</a></h3>
-
-                <p>These are snapshot builds for the current release, which will be released in the next xCAT refresh of the currently released version</p>
-
-                <h4>Linux - RPM Packages</h4>
-
-                <ul>
-                    <li>Download <a href="https://xcat.org/files/xcat/xcat-core/2.14.x_Linux/core-snap/core-rpms-snap.tar.bz2">core-rpms-snap.tar.bz2</a></li>
-
-                    <li>Linux Online Repository: <a href="https://xcat.org/files/xcat/repos/yum/2.14/core-snap/xcat-core.repo">xcat-core.repo</a></li>
-                </ul>
-
-                <h4>Linux - Debian Packages (Ubuntu)</h4>
-
-                <ul>
-                    <li>Download: <a href="https://xcat.org/files/xcat/xcat-core/2.14.x_Ubuntu/core-snap/core-debs-snap.tar.bz2" rel="nofollow">core-debs-snap.tar.bz2</a></li>
-
-                    <li>Ubuntu Online Repository:<br>
-                        &nbsp; <i>For x86_64 servers:</i>
-
-                        <p class="codetext">&nbsp; deb [arch=amd64] <a href="https://xcat.org/files/xcat/repos/apt/2.14/core-snap">https://xcat.org/files/xcat/repos/apt/2.14/core-snap</a> trusty main</p>&nbsp; <i>For ppc64el servers:</i>
-
-                        <p class="codetext">&nbsp; deb [arch=ppc64el] <a href="https://xcat.org/files/xcat/repos/apt/2.14/core-snap">https://xcat.org/files/xcat/repos/apt/2.14/core-snap</a> trusty main</p>
                     </li>
                 </ul>
                 <hr>


### PR DESCRIPTION
The development build and snapshot build are the same.
Remove snapshot build references from webpage to remove the confusion