### PR TITLE
Ubuntu commands in codebox

### DIFF
--- a/download.html
+++ b/download.html
@@ -175,9 +175,14 @@ chmod +x /tmp/go-xcat
                     <li>Ubuntu Online Repository:<br>
                         &nbsp; <i>For x86_64 servers:</i>
 
-                        <p class="codetext">&nbsp; deb [arch=amd64] <a href="https://xcat.org/files/xcat/repos/apt/2.14/xcat-core/">https://xcat.org/files/xcat/repos/apt/2.14/xcat-core</a> trusty main</p>&nbsp; <i>For ppc64el servers:</i>
+                        <div id="code_box">
+                            <p class="codetext">&nbsp; deb [arch=amd64] <a href="https://xcat.org/files/xcat/repos/apt/2.14/xcat-core/">https://xcat.org/files/xcat/repos/apt/2.14/xcat-core</a> trusty main</p>
+                        </div>
+                        &nbsp; <i>For ppc64el servers:</i>
+                        <div id="code_box">
 
-                        <p class="codetext">&nbsp; deb [arch=ppc64el] <a href="https://xcat.org/files/xcat/repos/apt/2.14/xcat-core/">https://xcat.org/files/xcat/repos/apt/2.14/xcat-core</a> trusty main</p>
+                            <p class="codetext">&nbsp; deb [arch=ppc64el] <a href="https://xcat.org/files/xcat/repos/apt/2.14/xcat-core/">https://xcat.org/files/xcat/repos/apt/2.14/xcat-core</a> trusty main</p>
+                        </div>
                     </li>
 
                     <li>Latest Repository (This repo points to the latest stable build of xCAT):<br>


### PR DESCRIPTION
Place Ubuntu commands in codeboxes to make it more clear that these need to be executed.