### PR TITLE
Point to readthedocs instead of sourceforge

### DIFF
--- a/download.html
+++ b/download.html
@@ -139,7 +139,7 @@ chmod +x /tmp/go-xcat
 
                 <li><a href="#development_builds">Development Builds</a> - snapshot builds of the next version of xCAT</li>
 
-                <li><a href="https://sourceforge.net/p/xcat/wiki/XCAT_Developer_Guide/#building-xcat-core-from-xcat-core-git-repository">Build the xcat-core tarball from source</a> - xCAT 2.10 and later supports building the xcat-core tarball from the cloned repository.</li>
+                <li><a href="https://xcat-docs.readthedocs.io/en/stable/developers/guides/code/builds.html">Build the xcat source</a> - xCAT 2.10 and later supports building the xcat-core from the cloned repository.</li>
             </ul><b><a href="#xcat-dep">xCAT Dependency Packages (xcat-dep)</a></b> is a tar package that is provided as a convenience for the user and contains dependency packages required by xCAT that are not provided by the operating system.
         </div><br>
         <br>


### PR DESCRIPTION
Reference read the docs instead of source forge from xcat.org page