### PR TITLE
Backup webcontent instead of css and images dirs

### DIFF
--- a/backup/backup_xcat.org.sh
+++ b/backup/backup_xcat.org.sh
@@ -2,7 +2,7 @@
 # This script is copied over to xcat.org and 
 # executed to tar up the directories in the list below
 
-SAVE_DIRECTORIES="./css ./images ./*.html ./files ./*.py"
+SAVE_DIRECTORIES="./*.html ./files ./*.py ./webcontent"
 
 DATE=`date +%Y%m%d`
 FILENAME="${DATE}-xcat.org-backup.tar.gz"


### PR DESCRIPTION
The `tar` error seen by #66 was probably caused by attempting to tar `css` and `images` directories, which are no longer there. Instead `webcontent` directory needs to be backed up.