### PR TITLE
Simplify xCAT download page

### DIFF
--- a/download.html
+++ b/download.html
@@ -5,7 +5,7 @@
     <meta name="GCD" content="YTk3ODQ3ZWZhN2I4NzZmMzBkNTEwYjJla2e24c1eb1704104e42a76dcd13809a5">
     <meta charset="utf-8">
 
-    <title>Download xCAT [2.14.6 - Stable Release]</title>
+    <title>Download xCAT [2.15 - Stable Release]</title>
     <meta name="generator" content="Google Web Designer 5.0.1.1129">
     <meta name="template" content="Expandable 3.0.0">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -107,40 +107,33 @@ html,
 
     <div class="container">
         <div class="download_main">
-            <h2>Installing with go-xcat</h2>To easily install xCAT and handle the dependency package, a new script <b>go-xcat</b> is provided.<br>
+            <h2>Installing with go-xcat (recommended)</h2>To simplify xCAT installation and its dependency packages, use <b>go-xcat</b> script.<br>
             <br>
-            On the target xCAT Management Node, run the following commands to install the latest version of xCAT:<br>
+            On the target xCAT Management Node, run the following commands to install the latest stable version of xCAT:<br>
             <br>
 
             <div id="code_box">
                 <pre class="codetext">
 wget https://raw.githubusercontent.com/xcat2/xcat-core/master/xCAT-server/share/xcat/tools/go-xcat -O - &gt;/tmp/go-xcat
 chmod +x /tmp/go-xcat
-/tmp/go-xcat
+/tmp/go-xcat install
 </pre>
             </div>
 
             <h2>Download xCAT</h2>
 
-            <p>There are a number of options provided for installing xCAT.</p>
+            <b><a href="#xcat-core">xCAT Core Packages (xcat-core)</a></b> is the main package containing the xCAT software.
+            <b><a href="#xcat-dep">xCAT Dependency Packages (xcat-dep)</a></b> is a tar package that is provided as a convenience for the user and contains dependency packages required by xCAT that are not provided by the operating system.
+
+            <p>There are 2 ways provided for installing xCAT.</p>
 
             <ol>
-                <li>Download the tar.bz2 packages provided on this download page</li>
+                <li>Download the tar.bz2 packages for both <tt>xcat-core</tt> and <tt>xcat-dep</tt> from this download page.</li>
 
-                <li>Configure the public hosted online repositories from your target machine</li>
+                <li>Configure publicly hosted online repositories for both <tt>xcat-core</tt> and <tt>xcat-dep</tt> on your target machine</li>
 
-                <li>Clone the xcat-core project and compile from source (still requires xcat-dep)</li>
             </ol>
 
-            <p>Regardless of the option that is chosen to install xCAT, <b>BOTH</b> <tt>xcat-core</tt> and <tt>xcat-dep</tt> are needed before starting the install.</p><b><a href="#xcat-core">xCAT Core Packages (xcat-core)</a></b> is the main package containing the xCAT software. The following builds are available:
-
-            <ul>
-                <li><a href="#release_builds">Release Build (Stable)</a> - latest generally available (GA) build for xCAT</li>
-
-                <li><a href="#development_builds">Development Builds</a> - snapshot builds of the next version of xCAT</li>
-
-                <li><a href="https://xcat-docs.readthedocs.io/en/stable/developers/guides/code/builds.html">Build the xcat source</a> - xCAT 2.10 and later supports building the xcat-core from the cloned repository.</li>
-            </ul><b><a href="#xcat-dep">xCAT Dependency Packages (xcat-dep)</a></b> is a tar package that is provided as a convenience for the user and contains dependency packages required by xCAT that are not provided by the operating system.
         </div><br>
         <br>
 
@@ -148,30 +141,27 @@ chmod +x /tmp/go-xcat
             <h2><a name="xcat-core">xCAT Core Packages (xcat-core)</a></h2>
 
             <div class="download_files">
-                <p><i><b>Looking for older releases of xCAT?</b> Go to the <a href="https://www.xcat.org/files/">File Manager</a> and navigate to the desired directory.</i></p>
                 <hr>
 
                 <h3><a name="release_builds">GA Release Build (Stable)</a></h3>
 
-                <p>This is the latest official released version of xCAT that has been fully tested.</p>
-
-                <h4>Linux - RPM Packages</h4>
+                <h4>Linux - RPM Packages [Select one of the choices below]</h4>
 
                 <ul>
                     <li>Download: 
                         <a href="https://xcat.org/files/xcat/xcat-core/2.14.x_Linux/xcat-core/xcat-core-2.14.6-linux.tar.bz2">xcat-core-2.14.6-linux.tar.bz2</a></li>
 
-                    <li>Latest GA Online Repository (This repo points to the latest stable build of xCAT): 
+                    <li>Public Online Repository: 
                         <a href="https://xcat.org/files/xcat/repos/yum/latest/xcat-core/xcat-core.repo">xcat-core.repo</a></li>
                 </ul>
 
-                <h4>Linux - Debian Packages (Ubuntu)</h4>
+                <h4>Linux - Debian Packages (Ubuntu) [Select one of the choices below]</h4>
 
                 <ul>
                     <li>Download: 
                         <a href="https://xcat.org/files/xcat/xcat-core/2.14.x_Ubuntu/xcat-core/xcat-core-2.14.6-ubuntu.tar.bz2" rel="nofollow">xcat-core-2.14.6-ubuntu.tar.bz2</a></li>
 
-                    <li>Latest GA Online Repository (This repo points to the latest stable build of xCAT):<br>
+                    <li>Public Online Repository:<br>
                         &nbsp; <i>For x86_64 servers:</i>
 
                         <div id="code_box">
@@ -186,27 +176,25 @@ chmod +x /tmp/go-xcat
                 </ul>
                 <hr>
 
-                <h3><a name="development_builds">Development Builds</a></h3>
+                <h3><a name="development_builds">Development Builds (Daily Snapshot)</a></h3>
 
-                <p>This is the latest development build for the next xCAT release</p>
-
-                <h4 class="linux-rpm-packages">Linux - RPM Packages</h4>
+                <h4 class="linux-rpm-packages">Linux - RPM Packages [Select one of the choices below]</h4>
 
                 <ul>
                     <li>Download: 
                         <a href="https://xcat.org/files/xcat/xcat-core/devel/Linux/core-snap/core-rpms-snap.tar.bz2">core-rpms-snap.tar.bz2</a></li>
 
-                    <li>Latest Online Development Repository (This repo points to the latest development build of xCAT): 
+                    <li>Public Online Development Repository: 
                         <a href="https://xcat.org/files/xcat/repos/yum/devel/core-snap/xcat-core.repo">xcat-core.repo</a></li>
                 </ul>
 
-                <h4>Linux - Debian Packages (Ubuntu)</h4>
+                <h4>Linux - Debian Packages (Ubuntu) [Select one of the choices below]</h4>
 
                 <ul>
                     <li>Download: 
                         <a href="https://xcat.org/files/xcat/xcat-core/devel/Ubuntu/core-snap/core-debs-snap.tar.bz2" rel="nofollow">core-debs-snap.tar.bz2</a></li>
 
-                    <li>Ubuntu Online Repository:<br>
+                    <li>Public Online Development Repository:<br>
                         &nbsp; <i>For x86_64 servers:</i>
 
                         <div id="code_box">
@@ -227,30 +215,27 @@ chmod +x /tmp/go-xcat
         <div class="download_section">
             <h2><a name="xcat-dep">xCAT Dependency Packages (xcat-dep)</a></h2>
 
-            <p> This contains dependency packages required by xCAT that are not provided by the operating system.</p>
-
-
             <div class="download_files">
-                <h4>Linux - RPM</h4>
+                <h4>Linux - RPM [Select one of the choices below]</h4>
 
                 <ul>
                     <li>Download: 
-                        <a href="https://xcat.org/files/xcat/xcat-dep/2.x_Linux/?C=M;O=D">xcat-dep</a> 
-                        Choose the file with the latest snapshot date</li>
+                        <a href="https://xcat.org/files/xcat/xcat-dep/2.x_Linux/?C=M;O=D">xcat-dep</a>. 
+                        Choose tar.bz2 file that matches the version number of <tt>xcat-core</tt> package. If installing the development build, choose the file with the latest snapshot date.</li>
 
-                    <li>Linux Online Repository: 
-                        <a href="https://xcat.org/files/xcat/repos/yum/xcat-dep">xcat-dep online repo</a> 
-                        From the online repo, select the <b>os/arch</b> of your management node and configure yum/zypper with the provided xcat-dep.repo file found in that directory.</li>
+                    <li>Online Repository: 
+                        <a href="https://xcat.org/files/xcat/repos/yum/xcat-dep">xcat-dep online repo</a>. 
+                        Select the <b>os/arch</b> of your management node and configure yum/zypper with the provided <tt>xcat-dep.repo</yy> file found in that directory.</li>
                 </ul>
 
-                <h4>Linux - Debian (Ubuntu)</h4>
+                <h4>Linux - Debian (Ubuntu) [Select one of the choices below]</h4>
 
                 <ul>
-                    <li>Download: 
-                        <a href="https://xcat.org/files/xcat/xcat-dep/2.x_Ubuntu/?C=M;O=D">xcat-dep</a> 
-                        Choose the file with the latest snapshot date</li>
+                    <li>Download:
+                        <a href="https://xcat.org/files/xcat/xcat-dep/2.x_Ubuntu/?C=M;O=D">xcat-dep</a>. 
+                        Choose the tar.bz2 file that matches the version number of <tt>xcat-core</tt> package. If installing the development build, choose the file with the latest snapshot date.</li>
 
-                    <li>Ubuntu Online Repository:<br>
+                    <li>Online Repository:<br>
                         &nbsp; <i>For x86_64 servers:</i>
 
                         <div id="code_box">


### PR DESCRIPTION
* Remove information about building your own xCAT
* Remove redundant instructions
* Indicate the `go-xcat` is recommended way to install