### PR TITLE
Back up files on xcat.org by directly saving the tar.gz file on the login node

### DIFF
--- a/backup/runbackup
+++ b/backup/runbackup
@@ -1,12 +1,17 @@
 #!/bin/sh
 
-SCRIPT=$(readlink -f $0)
-TARGET_DIR=/home/xcat
 TARGET=xcat@xcat.org
 
 BACKUP_DIRECTORY="/xcat/build/xcat.org_backup"
 
 LOGFILE=${BACKUP_DIRECTORY}/status.out
+
+SAVE_DIRECTORIES="./*.html ./files ./*.py ./webcontent"
+
+DATE=`date +%Y%m%d`
+FILENAME="${DATE}-xcat.org-backup.tar.gz"
+
+TARGET_TOPDIR=/var/www/xcat.org
 
 function LOGIT { 
     DATE=`date -R`
@@ -23,24 +28,10 @@ if [[ -d ${BACKUP_DIRECTORY} ]]; then
     ls -ltrh ${BACKUP_DIRECTORY}/*.tar.gz >>  ${LOGFILE} 2>&1
     LOGIT "======================================================="
 
-    BACKUP_SCRIPT="$(dirname ${SCRIPT})/backup_xcat.org.sh"
-    if [[ ! -x ${BACKUP_SCRIPT} ]]; then
-        echo "Cound not find the ${BACKUP_SCRIPT}, cannot continue!"
-        exit 1
-    fi
-
-    scp ${BACKUP_SCRIPT} ${TARGET}:${TARGET_DIR}
-
     LOGIT "Executing backup..."
-    ssh ${TARGET} ${TARGET_DIR}/backup_xcat.org.sh
+    ssh ${TARGET} "cd ${TARGET_TOPDIR} && tar cvzf - ${SAVE_DIRECTORIES}" > ${BACKUP_DIRECTORY}/${FILENAME}
 
-    LOGIT "Copying backup file to ${BACKUP_DIRECTORY}"
-    scp ${TARGET}:${TARGET_DIR}/*xcat.org-backup.tar.gz ${BACKUP_DIRECTORY}
-
-    LOGIT "Cleaning up xcat.org..."
-    ssh ${TARGET} rm ${TARGET_DIR}/*xcat.org-backup.tar.gz 
-
-    LOGIT "NEW BACKUP FILES\n"
+    LOGIT "Dispaying backups, including the new one:\n"
     LOGIT "======================================================="
     ls -ltrh ${BACKUP_DIRECTORY}/*.tar.gz >> ${LOGFILE}
     LOGIT "======================================================="
@@ -49,13 +40,10 @@ else
     exit 1
 fi 
 
-
 cat ${BACKUP_DIRECTORY}/status.out
-
-
 # Send out mail
-SUBJECT="==> xcat.org bi-weekly backup status"
+SUBJECT="==> xcat.org backup status"
 RETURN="root@`hostname -s`"
-RECIPIENT="cxhong@us.ibm.com,gurevich@us.ibm.com,besawn@us.ibm.com"
+RECIPIENT="wpeter@us.ibm.com,gurevich@us.ibm.com,besawn@us.ibm.com"
 
 mailx -s "$SUBJECT" -r ${RETURN} ${RECIPIENT} < ${LOGFILE}


### PR DESCRIPTION
Earlier, a tar.gz file was created on xcat.org and scp'ed to the login node.

Due to the limited storage space on xcat.log, this new method was provided by Nate to save the file directly on the login node.