### PR TITLE
Fixed xCAT deps link logic to use names based on the full version

### DIFF
--- a/promote_build.py
+++ b/promote_build.py
@@ -202,7 +202,7 @@ def promote_snap_build():
 
         # Link xcat-dep-<version> to the file with the latest date
         dep_path = "%s/xcat/xcat-dep/2.x_%s" %(os.path.realpath(options.TARGET), t)
-        cmd = "cd %s; ls %s | tail -1 | xargs -I {} ln -s {} xcat-dep-%s-%s.tar.bz2; cd -" %(dep_path, dep_file_prefix, major, str.lower(t))
+        cmd = "cd %s; ls %s | tail -1 | xargs -I {} ln -s {} xcat-dep-%s-%s.tar.bz2; cd -" %(dep_path, dep_file_prefix, minor, str.lower(t))
         run_command(cmd) 
 
         # remove the xcat-core repo


### PR DESCRIPTION
While promoting the xCAT core and deps builds as part of the 2.16.3 release process, I hit the following problem:

```
$ ./promote_build.py --debug --type=snap 2.16.3 --link_latest --force
Version passed in: 
    Major Version . . .: 2.16
    Minor Version . . .: 2.16.3
=== Promoting Linux release ===
...
Running cmd: cd /var/www/xcat.org/files/xcat/xcat-dep/2.x_Linux; ls xcat-dep-20* | tail -1 | xargs -I {} ln -s {} xcat-dep-2.16-linux.tar.bz2; cd -
ln: failed to create symbolic link 'xcat-dep-2.16-linux.tar.bz2': File exists
...
Running cmd: cd /var/www/xcat.org/files/xcat/xcat-dep/2.x_Ubuntu; ls xcat-dep-ubuntu-20* | tail -1 | xargs -I {} ln -s {} xcat-dep-2.16-ubuntu.tar.bz2; cd -
ln: failed to create symbolic link 'xcat-dep-2.16-ubuntu.tar.bz2': File exists
```
The problem is due to the promote script only using the major version of `2.16` instead of the full version of `2.16.3` when creating the link. Since `xcat-dep-2.16-linux.tar.bz2` already exists from when xCAT 2.16 when released in 2020, the link cannot be created:
```
xcat@sense:/var/www/xcat.org$ cd /var/www/xcat.org/files/xcat/xcat-dep/2.x_Linux/
xcat@sense:/var/www/xcat.org/files/xcat/xcat-dep/2.x_Linux$ ls -al xcat-dep-2.16*
lrwxrwxrwx 1 xcat xcat 29 Jun 18  2020 xcat-dep-2.16-linux.tar.bz2 -> xcat-dep-202006151012.tar.bz2
lrwxrwxrwx 1 xcat xcat 29 Jun 18  2020 xcat-dep-2.16.0-linux.tar.bz2 -> xcat-dep-202006151012.tar.bz2
lrwxrwxrwx 1 xcat xcat 29 Nov 10  2020 xcat-dep-2.16.1-linux.tar.bz2 -> xcat-dep-202011051627.tar.bz2
lrwxrwxrwx 1 xcat xcat 29 May 25 08:51 xcat-dep-2.16.2-linux.tar.bz2 -> xcat-dep-202105131519.tar.bz2
```
By changing the logic to use the minor version instead of major version, the link can be created successfully:
```
$ ./promote_build.py --type=snap 2.16.3 --link_latest --force
Version passed in: 
    Major Version . . .: 2.16
    Minor Version . . .: 2.16.3
=== Promoting Linux release ===
...
Running cmd: cd /var/www/xcat.org/files/xcat/xcat-dep/2.x_Linux; ls xcat-dep-20* | tail -1 | xargs -I {} ln -s {} xcat-dep-2.16.3-linux.tar.bz2; cd -
...
Running cmd: cd /var/www/xcat.org/files/xcat/xcat-dep/2.x_Ubuntu; ls xcat-dep-ubuntu-20* | tail -1 | xargs -I {} ln -s {} xcat-dep-2.16.3-ubuntu.tar.bz2; cd -
```

```
xcat@sense:/var/www/xcat.org$ cd /var/www/xcat.org/files/xcat/xcat-dep/2.x_Linux/
xcat@sense:/var/www/xcat.org/files/xcat/xcat-dep/2.x_Linux$ ls -al xcat-dep-2.16*
lrwxrwxrwx 1 xcat xcat 29 Jun 18  2020 xcat-dep-2.16-linux.tar.bz2 -> xcat-dep-202006151012.tar.bz2
lrwxrwxrwx 1 xcat xcat 29 Jun 18  2020 xcat-dep-2.16.0-linux.tar.bz2 -> xcat-dep-202006151012.tar.bz2
lrwxrwxrwx 1 xcat xcat 29 Nov 10  2020 xcat-dep-2.16.1-linux.tar.bz2 -> xcat-dep-202011051627.tar.bz2
lrwxrwxrwx 1 xcat xcat 29 May 25 08:51 xcat-dep-2.16.2-linux.tar.bz2 -> xcat-dep-202105131519.tar.bz2
lrwxrwxrwx 1 xcat xcat 29 Nov 17 08:44 xcat-dep-2.16.3-linux.tar.bz2 -> xcat-dep-202110151106.tar.bz2
```
